### PR TITLE
Implemented protocol-switch-aware redirect in Net, should fix #31

### DIFF
--- a/src/ch/fixme/status/Net.java
+++ b/src/ch/fixme/status/Net.java
@@ -54,10 +54,27 @@ public class Net {
 
         // Create client
         URL url = new URL(urlStr);
-        mUrlConnection = (HttpURLConnection) url.openConnection();
-        mUrlConnection.setRequestProperty("User-Agent", USERAGENT);
-        mUrlConnection.setUseCaches(useCache);
-        Log.v(Main.TAG, "fetching " + urlStr);
+
+        // HttpsURLConnection does not support redirect with protocol switch,
+        // so we take care of that here:
+        boolean redirect = false;
+        do {
+           mUrlConnection = (HttpURLConnection) url.openConnection();
+           mUrlConnection.setRequestProperty("User-Agent", USERAGENT);
+           mUrlConnection.setUseCaches(useCache);
+           Log.v(Main.TAG, "fetching " + urlStr);
+
+           if(mUrlConnection.getResponseCode() == HttpURLConnection.HTTP_MOVED_TEMP
+               || mUrlConnection.getResponseCode() == HttpURLConnection.HTTP_MOVED_PERM
+               || mUrlConnection.getResponseCode() == HTTP_TEMPORARY_REDIRECT
+               || mUrlConnection.getResponseCode() == HTTP_PERMANENT_REDIRECT) {
+
+               location = mUrlConnection.getHeaderField("Location");
+
+          } else {
+            redirect = false;
+          }
+       } while(redirect);
     }
 
     public String getString() throws Throwable {

--- a/src/ch/fixme/status/Net.java
+++ b/src/ch/fixme/status/Net.java
@@ -58,6 +58,7 @@ public class Net {
         // HttpsURLConnection does not support redirect with protocol switch,
         // so we take care of that here:
         boolean redirect = false;
+        int redirect_limt = 10;
         do {
            mUrlConnection = (HttpURLConnection) url.openConnection();
            mUrlConnection.setRequestProperty("User-Agent", USERAGENT);
@@ -70,11 +71,12 @@ public class Net {
                || mUrlConnection.getResponseCode() == HTTP_PERMANENT_REDIRECT) {
 
                location = mUrlConnection.getHeaderField("Location");
+               redirect_limt -= 1;
 
           } else {
             redirect = false;
           }
-       } while(redirect);
+       } while(redirect && redirect_limt > 0);
     }
 
     public String getString() throws Throwable {


### PR DESCRIPTION
**Problem:**
* HttpsURLConnection does not support redirects with protocol switch [See here why](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4620571)
* Everyone uses protocol switching to HTTPS redirects thanks to [Let's Encrypt](https://letsencrypt.org/)
* [```Net.getString()```](https://github.com/fixme-lausanne/MyHackerspace/blob/master/src/ch/fixme/status/Net.java#L63) throws a exception all the way up. :(
* For details see [Issue 31](https://github.com/fixme-lausanne/MyHackerspace/issues/31)

**Fix:**
* Implemented redirect which does not care about protocol switching.