### PR TITLE
Update Danish translation and use formal terms in English.

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -28,12 +28,12 @@
     <string name="error_title">Fejl: </string>
     <string name="error_network_title">Netværk</string>
     <string name="error_network_msg">Netværket er ikke tilgængeligt</string>
-    <string name="error_generic">\n\nKontroller at API\'et  overholder det niveau det annoncerer!\n\nSe http://spaceapi.net</string>
+    <string name="error_generic">\n\nKontroller at det aktive SpaceAPI overholder den revision det annoncerer!\n\nSe http://spaceapi.net</string>
 
-    <string name="prefs_api_title">SpaceAPI Endepunkt</string>
-    <string name="prefs_api_summary">URL til den globale SpaceAPI fortegnelse (directory.json fil)\nEksempler:\nhttps://spaceapi.fixme.ch/directory.json\nhttp://spaceapi.net/directory.json</string>
-    <string name="prefs_api_url_title">Current hackerspace API</string>
-    <string name="prefs_api_url_summary">Override current hackerspace URL (will be lost when choosing an other hackerspace in the list)</string>
+    <string name="prefs_api_title">Rediger OpenSpaceDirectory-URL</string>
+    <string name="prefs_api_summary">URL til den globale SpaceAPI-fortegnelse der skal anvendes (directory.json fil)\nEksempler:\nhttps://spaceapi.fixme.ch/directory.json\nhttp://spaceapi.net/directory.json</string>
+    <string name="prefs_api_url_title">Rediger SpaceAPI-URL</string>
+    <string name="prefs_api_url_summary">Ændr URL for det aktive SpaceAPI (mistes ved valg af hackerspace fra fortegnelsen)</string>
     <string name="prefs_interval_title">Opdateringsinterval</string>
     <string name="prefs_interval_summary">Interval i minutter imellem opdatering af widget-status</string>
     <string name="prefs_transparent_title">Gennemsigtig baggrund</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,12 +27,12 @@
     <string name="error_title">Error: </string>
     <string name="error_network_title">Network</string>
     <string name="error_network_msg">Network unreachable</string>
-    <string name="error_generic">\n\nCheck that the API conforms to the level it actually declares!\n\nSee http://spaceapi.net</string>
+    <string name="error_generic">\n\nCheck that the current SpaceAPI conforms to the level it actually declares!\n\nSee http://spaceapi.net</string>
 
-    <string name="prefs_api_title">SpaceAPI Endpoint</string>
-    <string name="prefs_api_summary">URL to the global SpaceAPI directory (directory.json file)\nExamples:\nhttps://spaceapi.fixme.ch/directory.json\nhttp://spaceapi.net/directory.json</string>
-    <string name="prefs_api_url_title">Current hackerspace API</string>
-    <string name="prefs_api_url_summary">Override current hackerspace URL (will be lost when choosing an other hackerspace in the list)</string>
+    <string name="prefs_api_title">Edit OpenSpaceDirectory URL</string>
+    <string name="prefs_api_summary">URL for the global SpaceAPI directory to use (directory.json file)\nExamples:\nhttps://spaceapi.fixme.ch/directory.json\nhttp://spaceapi.net/directory.json</string>
+    <string name="prefs_api_url_title">Edit SpaceAPI URL</string>
+    <string name="prefs_api_url_summary">Override current SpaceAPI URL (will be lost when choosing a hackerspace from the directory)</string>
     <string name="prefs_interval_title">Check interval</string>
     <string name="prefs_interval_summary">Interval in minutes to check the status in the widget</string>
     <string name="prefs_transparent_title">Show transparent background</string>


### PR DESCRIPTION
Danish:
Add missing translation of SpaceAPI URL edit feature.
Fix other minor issues.

Danish & English:
Consistently use the terms OpenSpaceDirectory and SpaceAPI.

Fixes #54 and partly #48.