### PR TITLE
Remove memorizing trust manager

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libs/MemorizingTrustManager"]
-	path = libs/MemorizingTrustManager
-	url = https://github.com/ge0rg/MemorizingTrustManager

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,18 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-21.1.1
+    - build-tools-29.0.2
 
     # The SDK version used to compile your project
-    - android-22
+    - android-29
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
-    - sys-img-armeabi-v7a-android-22
+    - sys-img-armeabi-v7a-android-29
 
 
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-29 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.1"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         applicationId "ch.fixme.status"
         minSdkVersion 14
-        targetSdkVersion 17
+        targetSdkVersion 29
         versionCode 20
         versionName "1.8.1"
     }
@@ -21,5 +21,5 @@ android {
 }
 
 dependencies {
-    compile project(':MemorizingTrustManager')
+    implementation project(':MemorizingTrustManager')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,5 +21,4 @@ android {
 }
 
 dependencies {
-    implementation project(':MemorizingTrustManager')
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:icon="@drawable/myhs"
         android:label="@string/app_name"
         android:theme="@style/LightThemeSelector"
-        android:allowBackup="true">
+        android:allowBackup="true"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
             android:name=".Main"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,10 +45,6 @@
             </intent-filter>
         </activity>
 
-        <activity android:name="de.duenndns.ssl.MemorizingActivity"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar"
-        />
-
         <receiver android:name=".Network">
             <intent-filter>
                 <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />

--- a/app/src/main/java/ch/fixme/status/Net.java
+++ b/app/src/main/java/ch/fixme/status/Net.java
@@ -26,8 +26,6 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.X509TrustManager;
 import javax.net.ssl.SSLContext;
 
-import de.duenndns.ssl.MemorizingTrustManager;
-
 // From CommonsWare and Android Blog
 // https://github.com/commonsguy/cw-android/tree/master/Internet
 // http://android-developers.blogspot.ch/2010/07/multithreading-for-performance.html
@@ -48,15 +46,6 @@ public class Net {
 
     public Net(String urlStr, boolean useCache, Context ctxt) throws Throwable {
         mCtxt = ctxt;
-        // register MemorizingTrustManager for HTTPS
-        SSLContext sc = SSLContext.getInstance("TLS");
-        MemorizingTrustManager mtm = new MemorizingTrustManager(mCtxt);
-        sc.init(null, new X509TrustManager[] { mtm }, new SecureRandom());
-        HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-        HttpsURLConnection.setDefaultHostnameVerifier(
-            mtm.wrapHostnameVerifier(HttpsURLConnection.getDefaultHostnameVerifier()));
-
-        // Create client
 
         // Connect to URL
         URL url;

--- a/app/src/main/java/ch/fixme/status/Widget.java
+++ b/app/src/main/java/ch/fixme/status/Widget.java
@@ -17,6 +17,8 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.graphics.Bitmap;
 import android.os.AsyncTask;
+import android.os.Handler;
+import android.os.Looper;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.View;
@@ -304,17 +306,22 @@ public class Widget extends AppWidgetProvider {
         @Override
         protected void onHandleIntent(Intent intent) {
             final Context ctxt = UpdateService.this;
-            int widgetId = intent.getIntExtra(
+            final int widgetId = intent.getIntExtra(
                     AppWidgetManager.EXTRA_APPWIDGET_ID,
                     AppWidgetManager.INVALID_APPWIDGET_ID);
             SharedPreferences prefs = PreferenceManager
                     .getDefaultSharedPreferences(ctxt);
             if (Main.checkNetwork(ctxt) && prefs.contains(Main.PREF_API_URL_WIDGET + widgetId)) {
-                String url = prefs.getString(Main.PREF_API_URL_WIDGET
+                final String url = prefs.getString(Main.PREF_API_URL_WIDGET
                         + widgetId, ParseGeneric.API_DEFAULT);
                 Log.i(TAG, "Update widgetid " + widgetId + " with url "
                         + url);
-                new GetApiTask(ctxt, widgetId).execute(url);
+                new Handler(Looper.getMainLooper()).post(new Runnable() {
+                    @Override
+                    public void run() {
+                        new GetApiTask(ctxt, widgetId).execute(url);
+                    }
+                });
             }
             stopSelf();
         }

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -13,7 +13,7 @@
 
     <item
         android:id="@+id/menu_refresh"
-        android:icon="@+drawable/ic_action_refresh"
+        android:icon="@drawable/ic_action_refresh"
         android:showAsAction="ifRoom|withText"
         android:title="@string/btn_refresh"/>
     

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Note: Since some spaces have HTTP endpoints (without TLS),
+    we must set "cleartextTrafficPermitted" to true. -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -13,7 +14,8 @@ buildscript {
 
 allprojects {
     repositories {
-        // Add custom repositories here
+        jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 07 19:37:30 CET 2017
+#Fri Feb 28 13:50:08 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,1 @@
 include ':app'
-include ':MemorizingTrustManager'
-project(':MemorizingTrustManager').projectDir = new File('libs/MemorizingTrustManager')


### PR DESCRIPTION
This is based on #69, so merge that one first.

I would propose to remove the MemorizingTrustManager. It's a nice tool, but it increases maintenance effort. Right now, we have a conflict between the build tools that we use ourselves and the build tools that the library uses. It's fixable of course, but on the other hand, we are accessing purely public information. Do we really need to verify fingerprints of untrusted TLS certificates to access that public information?

What are your thoughts, @rorist?