### PR TITLE
Bump minSdkVersion to 21 (Android 5.0)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "ch.fixme.status"
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 20
         versionName "1.8.1"


### PR DESCRIPTION
Unfortunately most Android 4.x don't even support TLSv1.2 out of the box without doing some hacks.