### PR TITLE
Fix #78: Overlapping Sensor Fields

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,4 +26,5 @@ android {
 
 dependencies {
     implementation "androidx.annotation:annotation:1.1.0"
+    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
 }

--- a/app/src/main/java/ch/fixme/status/Main.java
+++ b/app/src/main/java/ch/fixme/status/Main.java
@@ -37,7 +37,6 @@ import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 import android.widget.SectionIndexer;
 import android.widget.TextView;
@@ -60,6 +59,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import androidx.annotation.UiThread;
+import androidx.constraintlayout.widget.ConstraintLayout;
 
 public class Main extends Activity {
 
@@ -700,65 +700,65 @@ public class Main extends Activity {
                     ArrayList<HashMap<String, String>> sensorsData = sensors
                             .get(name);
                     for (HashMap<String, String> elem : sensorsData) {
-                        RelativeLayout rl = (RelativeLayout) iftr.inflate(
+                        ConstraintLayout sensorView = (ConstraintLayout) iftr.inflate(
                                 R.layout.entry_sensor, null);
                         if (elem.containsKey(ParseGeneric.API_SENSOR_VALUE)) {
-                            ((TextView) rl.findViewById(R.id.entry_value))
+                            ((TextView) sensorView.findViewById(R.id.entry_value))
                                     .setText(elem.get(ParseGeneric.API_SENSOR_VALUE));
                         } else {
-                            rl.findViewById(R.id.entry_value).setVisibility(
+                            sensorView.findViewById(R.id.entry_value).setVisibility(
                                     View.GONE);
                         }
                         if (elem.containsKey(ParseGeneric.API_SENSOR_UNIT)) {
-                            ((TextView) rl.findViewById(R.id.entry_unit))
+                            ((TextView) sensorView.findViewById(R.id.entry_unit))
                                     .setText(elem.get(ParseGeneric.API_SENSOR_UNIT));
                         } else {
-                            rl.findViewById(R.id.entry_unit).setVisibility(
+                            sensorView.findViewById(R.id.entry_unit).setVisibility(
                                     View.GONE);
                         }
                         if (elem.containsKey(ParseGeneric.API_SENSOR_NAME)) {
-                            ((TextView) rl.findViewById(R.id.entry_name))
+                            ((TextView) sensorView.findViewById(R.id.entry_name))
                                     .setText(elem.get(ParseGeneric.API_SENSOR_NAME));
                         } else {
-                            rl.findViewById(R.id.entry_name).setVisibility(
+                            sensorView.findViewById(R.id.entry_name).setVisibility(
                                     View.GONE);
                         }
                         if (elem.containsKey(ParseGeneric.API_SENSOR_LOCATION)) {
-                            ((TextView) rl.findViewById(R.id.entry_location))
+                            ((TextView) sensorView.findViewById(R.id.entry_location))
                                     .setText(elem
                                             .get(ParseGeneric.API_SENSOR_LOCATION));
                         } else {
-                            rl.findViewById(R.id.entry_location).setVisibility(
+                            sensorView.findViewById(R.id.entry_location).setVisibility(
                                     View.GONE);
                         }
                         if (elem.containsKey(ParseGeneric.API_SENSOR_DESCRIPTION)) {
-                            ((TextView) rl.findViewById(R.id.entry_description))
+                            ((TextView) sensorView.findViewById(R.id.entry_description))
                                     .setText(elem
                                             .get(ParseGeneric.API_SENSOR_DESCRIPTION));
                         } else {
-                            rl.findViewById(R.id.entry_description)
+                            sensorView.findViewById(R.id.entry_description)
                                     .setVisibility(View.GONE);
                         }
                         if (elem.containsKey(ParseGeneric.API_SENSOR_PROPERTIES)) {
-                            ((TextView) rl.findViewById(R.id.entry_properties))
+                            ((TextView) sensorView.findViewById(R.id.entry_properties))
                                     .setText(elem
                                             .get(ParseGeneric.API_SENSOR_PROPERTIES));
                         } else {
-                            rl.findViewById(R.id.entry_properties)
+                            sensorView.findViewById(R.id.entry_properties)
                                     .setVisibility(View.GONE);
                         }
                         if (elem.containsKey(ParseGeneric.API_SENSOR_MACHINES)) {
-                            ((TextView) rl.findViewById(R.id.entry_other))
+                            ((TextView) sensorView.findViewById(R.id.entry_other))
                                     .setText(elem
                                             .get(ParseGeneric.API_SENSOR_MACHINES));
                         } else if (elem.containsKey(ParseGeneric.API_SENSOR_NAMES)) {
-                            ((TextView) rl.findViewById(R.id.entry_other))
+                            ((TextView) sensorView.findViewById(R.id.entry_other))
                                     .setText(elem.get(ParseGeneric.API_SENSOR_NAMES));
                         } else {
-                            rl.findViewById(R.id.entry_other).setVisibility(
+                            sensorView.findViewById(R.id.entry_other).setVisibility(
                                     View.GONE);
                         }
-                        vg.addView(rl);
+                        vg.addView(sensorView);
                     }
                 }
             }

--- a/app/src/main/res/layout/entry_sensor.xml
+++ b/app/src/main/res/layout/entry_sensor.xml
@@ -3,31 +3,33 @@
     Copyright (C) 2012 Aubort Jean-Baptiste (Rorist)
     Licensed under GNU's GPL 3, see README
 -->
-<RelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingBottom="2dip"
     android:paddingTop="2dip"
     android:layout_marginBottom="2dip"
     android:layout_marginTop="2dip">
+
     <ImageView
         android:id="@+id/entry_img"
         android:layout_width="wrap_content"
-        android:layout_height="fill_parent"
-        android:layout_alignParentLeft="true"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         android:paddingTop="8dip"
-        android:paddingRight="8dip"
+        android:paddingStart="0dip"
+        android:paddingEnd="8dip"
         android:paddingBottom="8dip"
-        android:src="@android:drawable/sym_contact_card"/>
+        android:src="@android:drawable/sym_contact_card" />
     <TextView
         android:id="@+id/entry_value"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/entry_img"
-        android:layout_alignParentTop="true"
-        android:layout_alignWithParentIfMissing="true"
-        android:layout_marginRight="4dip"
+        app:layout_constraintStart_toEndOf="@id/entry_img"
+        app:layout_constraintTop_toTopOf="parent"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textIsSelectable="true"
         android:text="20" />
@@ -35,64 +37,63 @@
         android:id="@+id/entry_unit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/entry_value"
-        android:layout_alignParentTop="true"
-        android:layout_alignWithParentIfMissing="true"
+        android:layout_marginStart="4dp"
+        android:text="°C"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textIsSelectable="true"
-        android:text="°C" />
+        app:layout_constraintBaseline_toBaselineOf="@id/entry_value"
+        app:layout_constraintStart_toEndOf="@id/entry_value" />
     <TextView
         android:id="@+id/entry_properties"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/entry_img"
-        android:layout_below="@id/entry_value"
-        android:layout_marginRight="4dip"
+        app:layout_constraintStart_toEndOf="@id/entry_img"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/entry_value"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textIsSelectable="true"
         android:text="speed: 0 m/s, gust: 0 m/s" />
     <TextView
         android:id="@+id/entry_name"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/entry_img"
-        android:layout_below="@id/entry_properties"
-        android:layout_alignWithParentIfMissing="true"
-        android:layout_marginRight="8dip"
+        app:layout_constraintStart_toEndOf="@id/entry_img"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/entry_properties"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textIsSelectable="true"
         android:text="Sensor1" />
     <TextView
         android:id="@+id/entry_location"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/entry_name"
-        android:layout_below="@id/entry_properties"
-        android:layout_alignWithParentIfMissing="true"
+        app:layout_constraintStart_toEndOf="@id/entry_img"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/entry_name"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textIsSelectable="true"
         android:text="Outside" />
     <TextView
         android:id="@+id/entry_description"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/entry_img"
-        android:layout_below="@id/entry_name"
-        android:layout_alignWithParentIfMissing="true"
+        app:layout_constraintStart_toEndOf="@id/entry_img"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/entry_location"
         android:autoLink="all"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textIsSelectable="true"
         android:text="Description of the sensor" />
     <TextView
         android:id="@+id/entry_other"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/entry_img"
-        android:layout_below="@id/entry_description"
-        android:layout_alignParentBottom="true"
-        android:layout_alignWithParentIfMissing="true"
+        app:layout_constraintStart_toEndOf="@id/entry_img"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/entry_description"
+        app:layout_constraintBottom_toBottomOf="parent"
         android:autoLink="all"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textIsSelectable="true"
         android:text="{other: stuff}" />
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR fixes #78 by using a `ConstraintLayout` rather than a `RelativeLayout` for layouting the sensor fields.

This introduces another dependency (`ConstraintLayout` comes in a separate androidx support library), but `RelativeLayout` doesn't handle this specific case very well, and creating this layout with `LinearLayout` would require multiple levels of nesting.

Before:
![before](https://user-images.githubusercontent.com/5564491/81802621-b6634680-9516-11ea-872b-2f4f882b2047.jpg)

After:
![after](https://user-images.githubusercontent.com/5564491/81802655-c1b67200-9516-11ea-942a-700c808b7be8.jpg)
